### PR TITLE
#4 - SP_Levels will keep an updated cache of its tile counts, #3 - Th…

### DIFF
--- a/superplexed/source/sp_levels/SP_Level.h
+++ b/superplexed/source/sp_levels/SP_Level.h
@@ -28,6 +28,9 @@ class SP_Level {
 	bool m_gravity, m_freeze_zonks;
 	unsigned int m_player_x, m_player_y;
 	byte m_solve_it_count, m_sf_version;
+	std::vector<int> m_tile_counts;
+
+	void recalculate_tile_counts(void);
 	void apply_wall_border(void);
 	
 public:
@@ -53,7 +56,8 @@ public:
 	const std::vector<byte>& get_unused_bytes(void) const;
 	const std::vector<byte>& get_solution_bytes(void) const;
 	byte get_speedfix_version(void) const;
-	std::vector<int> get_tile_counts(void) const;
+	const std::vector<int>& get_tile_counts(void) const;
+	int get_tile_count(byte p_tile_no) const;
 	std::set<std::pair<int, int>> get_gp_positions(void) const;
 
 	// gravity port getters

--- a/superplexed/source/sp_wins/Level_window.cpp
+++ b/superplexed/source/sp_wins/Level_window.cpp
@@ -322,7 +322,9 @@ void Level_window::move(int p_delta_ms, const klib::User_input& p_input, SP_Conf
 		}
 		else if (p_input.mouse_held(false)) {
 			auto tcoords = mouse_coords_to_tile(p_input.mx(), p_input.my(), p_h);
-			if (l_ctrl) {
+			if (m_sel_tile == c::TILE_NO_PLAYER_START)
+				get_current_level().set_player_start(tcoords.first, tcoords.second);
+			else if (l_ctrl) {
 				byte l_source_col{ get_current_level().get_tile_no(tcoords.first, tcoords.second) };
 				byte l_target_col{ static_cast<byte>(m_sel_tile) };
 				if (l_source_col != l_target_col) {
@@ -331,8 +333,6 @@ void Level_window::move(int p_delta_ms, const klib::User_input& p_input, SP_Conf
 					commit_undo_block();
 				}
 			}
-			else if (m_sel_tile == c::TILE_NO_PLAYER_START)
-				get_current_level().set_player_start(tcoords.first, tcoords.second);
 			else
 				set_tile_value(tcoords.first, tcoords.second, m_sel_tile, true);
 		}

--- a/superplexed/source/sp_wins/Level_window_ui.cpp
+++ b/superplexed/source/sp_wins/Level_window_ui.cpp
@@ -219,10 +219,19 @@ void Level_window::draw_ui_level_win(const klib::User_input& p_input, const Proj
 		get_current_level().set_title(std::string(l_lvl_title));
 
 	// solve infotron count
-	std::string l_solve_it_id{ "#Infotrons###it" + l_clvl };
+	std::string l_solve_it_id{ "Infotrons###it" + l_clvl };
 	int l_solve_it_cnt = get_current_level().get_solve_it_count();
 	if (ImGui::SliderInt(l_solve_it_id.c_str(), &l_solve_it_cnt, 0, 255))
 		get_current_level().set_solve_it_count(l_solve_it_cnt);
+
+	std::string l_infotron_toolip{ "Infotrons: " +
+		std::to_string(get_current_level().get_tile_count(c::TILE_NO_INFOTRON)) +
+		", Electrons: " +
+		std::to_string(get_current_level().get_tile_count(c::TILE_NO_ELECTRON))
+	};
+
+	if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+		ImGui::SetTooltip(l_infotron_toolip.c_str());
 
 	// gravity
 	std::string l_grav_id{ "Gravity###grav" + l_clvl };


### PR DESCRIPTION
#4 - Level objects will keep a synced cache of its tile counts. Added tooltip to the infotron slider to show infotron and electron counts. #3 - The default level will have a required infontron count of 0 (=100%), and #2 - Color fill will not apply when the selected tile is the player start position