### PR TITLE
Add solution for issue #6 - can now define a levelset from assorted s…

### DIFF
--- a/superplexed/source/SP_Config.h
+++ b/superplexed/source/SP_Config.h
@@ -3,29 +3,37 @@
 
 #include <deque>
 #include <string>
+#include <vector>
+#include <utility>
 
 class SP_Config {
-
-	std::deque<std::string> m_messages;
-	std::string m_project_folder;
-	// levelset number: -1 is LEVELS.DAT and LEVEL.LST, 00 to 99 is LEVELS.Dxx, LEVEL.Lxx etc
-	int m_levelset_no;
-
-	std::string get_folder(const std::string& p_subfolder) const;
-	std::string get_full_path(const std::string& p_filename, const std::string& p_extension) const;
-
-	static std::string get_full_filename(const std::string& p_filename, const std::string& p_suffix);
-	std::string get_full_path_ignore_extension(const std::string& p_full_filename) const;
-	std::string get_levelset_lst_filename(void) const;
-	std::string get_levelset_dat_filename(void) const;
-	std::string get_prefix(void) const;
-	std::string strnum(void) const;
-
-
 public:
+
+	enum class SP_file_type { bmp, dat, sp, xml };
+
+	struct Predefined_levelset {
+		std::string m_levelset_filename;
+		int m_level_count;
+
+		std::vector<std::pair<std::string, int>> m_files;
+		Predefined_levelset(void) : m_level_count{ 0 }
+		{}
+		Predefined_levelset(const std::string& p_lvlset_filename, int p_lvl_count) :
+			m_levelset_filename{ p_lvlset_filename }, m_level_count{ p_lvl_count }
+		{}
+		void add_file(const std::string& p_path, int dat_lvl_no) {
+			m_files.push_back(std::make_pair(p_path, dat_lvl_no));
+		}
+		bool empty(void) const {
+			return m_files.empty();
+		}
+	};
+
 	SP_Config(void);
 	void add_message(const std::string& p_msg, bool p_prevent_repeat = false);
 	const std::deque<std::string>& get_messages(void) const;
+	const Predefined_levelset& get_predefined_levelset(void) const;
+	bool has_predefined_levelset(void) const;
 
 	std::string get_extension(char p_first_letter) const;
 
@@ -59,6 +67,28 @@ public:
 	// default level filename LEVELS.DAT
 	static std::string get_default_levels_filename(void);
 	void set_level_list_filename(const std::string& p_filename);
+
+	static SP_file_type get_file_type_from_path(const std::string& p_file_path);
+
+private:
+	SP_Config::Predefined_levelset m_predefined_levelset;
+	std::deque<std::string> m_messages;
+	std::string m_project_folder;
+	// levelset number: -1 is LEVELS.DAT and LEVEL.LST, 00 to 99 is LEVELS.Dxx, LEVEL.Lxx etc
+	int m_levelset_no;
+
+
+	std::string get_folder(const std::string& p_subfolder) const;
+	std::string get_full_path(const std::string& p_filename, const std::string& p_extension) const;
+
+	static std::string get_full_filename(const std::string& p_filename, const std::string& p_suffix);
+
+	std::string get_full_path_ignore_extension(const std::string& p_full_filename) const;
+	std::string get_levelset_lst_filename(void) const;
+	std::string get_levelset_dat_filename(void) const;
+	std::string get_prefix(void) const;
+	std::string strnum(void) const;
+
 };
 
 #endif

--- a/superplexed/source/SP_Constants.h
+++ b/superplexed/source/SP_Constants.h
@@ -3,8 +3,8 @@
 
 namespace c {
 	// application constants
-	constexpr char APP_TITLE[]{ "Superplexed v0.11" };
-	constexpr char APP_VERSION[]{ "0.11" };
+	constexpr char APP_TITLE[]{ "Superplexed v0.2-snapshot" };
+	constexpr char APP_VERSION[]{ "0.2-snapshot" };
 	constexpr int APP_WIN_W_INITIAL{ 1024 };
 	constexpr int APP_WIN_H_INITIAL{ 768 };
 	constexpr char FILE_SIGNATURE[]{ "kaimitai@github " };
@@ -21,6 +21,12 @@ namespace c {
 	constexpr char SUFFIX_LST[]{ "LST" };
 	constexpr char SUFFIX_SP[]{ "SP" };
 	constexpr char SUFFIX_XML[]{ "xml" };
+
+	constexpr char SUFFIX_DAT_UC[]{ "DAT" };
+	constexpr char SUFFIX_BMP_UC[]{ "BMP" };
+	constexpr char SUFFIX_LST_UC[]{ "LST" };
+	constexpr char SUFFIX_SP_UC[]{ "SP" };
+	constexpr char SUFFIX_XML_UC[]{ "XML" };
 
 	// output messages
 	constexpr unsigned int MESSAGES_MAX_SIZE{ 25 };
@@ -56,6 +62,14 @@ namespace c {
 	constexpr char XML_TAG_GPS[]{ "special_ports" };
 	constexpr char XML_TAG_GP[]{ "special_port" };
 	constexpr char XML_TAG_SOLUTION[]{ "speedfix_solution" };
+
+	constexpr char XML_TAG_PREDEFINED[]{ "predefined_levelset" };
+	constexpr char XML_TAG_LEVEL_FILE[]{ "level_file" };
+
+	constexpr char XML_ATTR_FILENAME[]{ "filename" };
+	constexpr char XML_ATTR_LEVEL_COUNT[]{ "level_count" };
+	constexpr char XML_ATTR_FILEPATH[]{ "filepath" };
+	constexpr char XML_ATTR_LEVEL_NO[]{ "level_no" };
 
 	constexpr char XML_ATTR_APP_VERSION[]{ "app_version" };
 	constexpr char XML_ATTR_TITLE[]{ "title" };

--- a/superplexed/source/sp_wins/Level_window.h
+++ b/superplexed/source/sp_wins/Level_window.h
@@ -17,7 +17,6 @@
 #include "./../SP_Constants.h"
 
 class Level_window {
-	enum class SP_file_type { bmp, dat, sp, xml };
 
 	struct Level {
 		SP_Level m_level;
@@ -78,12 +77,16 @@ class Level_window {
 	void toggle_selected_gp_property(int p_property_no);
 	void floorfill(byte p_source_col, byte p_target_col, int p_x, int p_y);
 
+	// file definitions
+	void load_predefined_levelset(const SP_Config& p_config);
+	SP_Level level_xml_from_file(const std::string& p_filepath) const;
+	SP_Level level_sp_from_file(const std::string& p_filepath) const;
+	SP_Level level_dat_from_file(const std::string& p_filepath, std::size_t p_level_no) const;
+
 	// xml read/write
 	void save_xml(std::size_t p_level_no, const SP_Config& p_config) const;
-	SP_Level load_xml(std::size_t p_level_no, const SP_Config& p_config) const;
 	// sp read/write
 	void save_sp(std::size_t p_level_no, const SP_Config& p_config) const;
-	SP_Level load_sp(std::size_t p_level_no, const SP_Config& p_config) const;
 	// dat read/write
 	void load_levels_dat(SP_Config& p_config);
 	void save_levels_dat(SP_Config& p_config);
@@ -94,8 +97,8 @@ class Level_window {
 	void draw_ui_statistics(const Project_gfx& p_gfx);
 
 	// general procedures for saving to and loading from files
-	void load_file(SP_file_type p_ftype, SP_Config& p_config, bool p_all);
-	void save_file(SP_file_type p_ftype, SP_Config& p_config, const Project_gfx& p_gfx, bool p_all) const;
+	void load_file(SP_Config::SP_file_type p_ftype, SP_Config& p_config, bool p_all);
+	void save_file(SP_Config::SP_file_type p_ftype, SP_Config& p_config, const Project_gfx& p_gfx, bool p_all) const;
 
 	void commit_undo_block(void);
 	void set_tile_value(int p_x, int p_y, byte p_value, bool p_autocommit = false);

--- a/superplexed/source/sp_wins/Level_window_ui.cpp
+++ b/superplexed/source/sp_wins/Level_window_ui.cpp
@@ -280,13 +280,13 @@ void Level_window::draw_ui_level_win(const klib::User_input& p_input, const Proj
 		save_levels_dat(p_config);
 	ImGui::SameLine();
 	if (ImGui::Button(c::SAVE_XML))
-		save_file(SP_file_type::xml, p_config, p_gfx, l_shift);
+		save_file(SP_Config::SP_file_type::xml, p_config, p_gfx, l_shift);
 	ImGui::SameLine();
 	if (ImGui::Button(c::SAVE_SP))
-		save_file(SP_file_type::sp, p_config, p_gfx, l_shift);
+		save_file(SP_Config::SP_file_type::sp, p_config, p_gfx, l_shift);
 	ImGui::SameLine();
 	if (ImGui::Button(c::SAVE_BMP))
-		save_file(SP_file_type::bmp, p_config, p_gfx, l_shift);
+		save_file(SP_Config::SP_file_type::bmp, p_config, p_gfx, l_shift);
 	// load from disk
 	if (ImGui::Button(l_load_dat.c_str()) && l_ctrl)
 		load_levels_dat(p_config);
@@ -294,12 +294,12 @@ void Level_window::draw_ui_level_win(const klib::User_input& p_input, const Proj
 		ImGui::SetTooltip(c::TXT_HOLD_CTRL_TO_USE);
 	ImGui::SameLine();
 	if (ImGui::Button(c::LOAD_XML) && l_ctrl)
-		load_file(SP_file_type::xml, p_config, l_shift);
+		load_file(SP_Config::SP_file_type::xml, p_config, l_shift);
 	if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 		ImGui::SetTooltip(c::TXT_HOLD_CTRL_TO_USE);
 	ImGui::SameLine();
 	if (ImGui::Button(c::LOAD_SP) && l_ctrl)
-		load_file(SP_file_type::sp, p_config, l_shift);
+		load_file(SP_Config::SP_file_type::sp, p_config, l_shift);
 	if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 		ImGui::SetTooltip(c::TXT_HOLD_CTRL_TO_USE);
 

--- a/superplexed/source/sp_wins/Level_window_xml.cpp
+++ b/superplexed/source/sp_wins/Level_window_xml.cpp
@@ -97,10 +97,10 @@ void Level_window::save_xml(std::size_t p_level_no, const SP_Config& p_config) c
 		throw std::runtime_error("Could not save XML");
 }
 
-SP_Level Level_window::load_xml(std::size_t p_level_no, const SP_Config& p_config) const {
+SP_Level Level_window::level_xml_from_file(const std::string& p_filepath) const {
 	pugi::xml_document doc;
-	if (!doc.load_file(p_config.get_xml_full_path(p_level_no).c_str()))
-		throw std::runtime_error("Could not load xml");
+	if (!doc.load_file(p_filepath.c_str()))
+		throw std::runtime_error("Could not load " + p_filepath);
 
 	pugi::xml_node n_meta = doc.child(c::XML_TAG_META);
 	auto n_level = n_meta.child(c::XML_TAG_LEVEL);

--- a/superplexed/source/sp_wins/Level_windows_file.cpp
+++ b/superplexed/source/sp_wins/Level_windows_file.cpp
@@ -1,0 +1,29 @@
+#include "Level_window.h"
+#include "./../common/pugixml/pugixml.hpp"
+#include "./../common/pugixml/pugiconfig.hpp"
+#include "./../common/klib/klib_util.h"
+#include "./../sp_levels/SP_Level.h"
+#include "./../SP_Config.h"
+#include "./../SP_Constants.h"
+#include <algorithm>
+#include <stdexcept>
+#include <tuple>
+
+void Level_window::load_predefined_levelset(const SP_Config& p_config) {
+	const auto& l_defs{ p_config.get_predefined_levelset() };
+
+	for (const auto& l_file : l_defs.m_files) {
+		std::string l_filepath = l_file.first;
+		std::size_t l_lvl_no = l_file.second;
+
+		if (SP_Config::get_file_type_from_path(l_filepath) == SP_Config::SP_file_type::xml)
+			m_levels.push_back(level_xml_from_file(l_filepath));
+		else if (SP_Config::get_file_type_from_path(l_filepath) == SP_Config::SP_file_type::sp)
+			m_levels.push_back(level_sp_from_file(l_filepath));
+		else if (SP_Config::get_file_type_from_path(l_filepath) == SP_Config::SP_file_type::dat)
+			m_levels.push_back(level_dat_from_file(l_filepath, l_lvl_no));
+	}
+
+	while (m_levels.size() < l_defs.m_level_count)
+		m_levels.push_back(SP_Level());
+}

--- a/superplexed/superplexed.vcxproj
+++ b/superplexed/superplexed.vcxproj
@@ -194,6 +194,7 @@
     <ClCompile Include="source\sp_saves\SP_Player_List.cpp" />
     <ClCompile Include="source\sp_wins\Graphics_window.cpp" />
     <ClCompile Include="source\sp_wins\Level_window.cpp" />
+    <ClCompile Include="source\sp_wins\Level_windows_file.cpp" />
     <ClCompile Include="source\sp_wins\Level_window_ui.cpp" />
     <ClCompile Include="source\sp_wins\Level_window_xml.cpp" />
     <ClCompile Include="source\sp_wins\Main_window.cpp" />

--- a/superplexed/superplexed.vcxproj.filters
+++ b/superplexed/superplexed.vcxproj.filters
@@ -233,5 +233,8 @@
     <ClCompile Include="source\sp_levels\SP_Level_undo_interface.cpp">
       <Filter>Source Files\sp_levels</Filter>
     </ClCompile>
+    <ClCompile Include="source\sp_wins\Level_windows_file.cpp">
+      <Filter>Source Files\sp_wins</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
…tandalone level files or levelset files in the config xml, and this will then be loaded instead of LEVELS.DAT on application start. Took the opportunity to move enum SP_file_type from the Level_window to the SP_Config class