### PR TITLE
Support empty file_path-tags in a predefined levelset

### DIFF
--- a/superplexed/docs/examples/spconfig.xml
+++ b/superplexed/docs/examples/spconfig.xml
@@ -3,11 +3,16 @@
 
 <!-- predefined levelset example file -->
 <superplexed app_version="0.2" project_folder="." undo_history="1000">
-  <!-- if level_count is given, the end of the file will be padded with empty levels. in this case it would be three since only five levels are specified below -->
+  
+  <!-- if level_count is given, the end of the file will be padded with empty levels. in this case two empty levels would be added
+  at the end, since only six levels are specified below -->
+  
   <predefined_levelset filename="example.dat" level_count="8">
   
 	<level_file filepath="./xml_file.xml" />
 	<level_file filepath="./sp_file.sp" />
+	<!-- If an empty tag is given, an empty level will be initialized at this position -->
+	<level_file />
 	<level_file filepath="c:/absolute/path/to/sp_file.sp" />
 	<!-- for dat-levelset files, specify which level number to import -->
 	<level_file filepath="./levels.dat" level_no="111" />

--- a/superplexed/docs/readme.html
+++ b/superplexed/docs/readme.html
@@ -101,7 +101,7 @@
                 <p>By default the file points to the gamedata folder which ships with the editor. If spconfig.xml cannot be found, the project folder will be the same as the executable folder, and the undo history will be 200.</p>
 				
 				<p>
-				   The configuration file can also define a levelset file which will be generated on startup, which can import files from different sources. All level file formats are supported for import, but for dat-levelset files you also need to specify which level number to import. See the <a href="./examples/spconfig_predefined_levelset.xml">example xml</a>.
+				   The configuration file can also define a levelset file which will be generated on startup, which can import files from different sources. All level file formats are supported for import, but for dat-levelset files you also need to specify which level number to import. See the <a href="./examples/spconfig.xml">example xml</a>.
 				</p>
 
             </section>

--- a/superplexed/source/sp_wins/Level_windows_file.cpp
+++ b/superplexed/source/sp_wins/Level_windows_file.cpp
@@ -16,7 +16,10 @@ void Level_window::load_predefined_levelset(const SP_Config& p_config) {
 		std::string l_filepath = l_file.first;
 		std::size_t l_lvl_no = l_file.second;
 
-		if (SP_Config::get_file_type_from_path(l_filepath) == SP_Config::SP_file_type::xml)
+		// if not filepath is given, insert an empty level at this point
+		if (l_filepath.empty())
+			m_levels.push_back(SP_Level());
+		else if (SP_Config::get_file_type_from_path(l_filepath) == SP_Config::SP_file_type::xml)
 			m_levels.push_back(level_xml_from_file(l_filepath));
 		else if (SP_Config::get_file_type_from_path(l_filepath) == SP_Config::SP_file_type::sp)
 			m_levels.push_back(level_sp_from_file(l_filepath));


### PR DESCRIPTION
Empty tags will inform the application to insert an empty level at certain locations, instead of importing from files